### PR TITLE
Bump enonic libs for XP 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,4 +19,5 @@ repositories {
 	mavenLocal()
 	mavenCentral()
 	xp.enonicRepo()
+	xp.enonicRepo('dev')
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 thymeleaf = "2.1.1"
-util = "3.1.1"
+util = "4.0.0-SNAPSHOT"
 xslt = "2.1.1"
 
 [libraries]


### PR DESCRIPTION
## Summary

Pins `lib-util` to the master SNAPSHOT published from the XP 8-targeted upgrade in `enonic/lib-util`. The libs aren't being released yet, so consumers point directly at the snapshot artifact resolved from the Enonic dev repo.

### Versions

| Dep                       | Before  | After             |
|---------------------------|---------|-------------------|
| `com.enonic.lib:lib-util` | `3.1.1` | `4.0.0-SNAPSHOT`  |

Both new pins are SNAPSHOTs that resolve via `xp.enonicRepo('dev')`.

### Repo declarations

`xp.enonicRepo('dev')` was **added** to `repositories {}` in `build.gradle`. The default `xp.enonicRepo()` was already declared but is the release repo and does not host snapshot artifacts.

### Excludes audit

None. `build.gradle` declares the libs as plain `include libs.lib.util` etc., with no `exclude` clauses anywhere — nothing to remove or re-evaluate.

### Verification

- `./gradlew clean build` — green.
- `./gradlew dependencies --configuration include` confirms `com.enonic.lib:lib-util:4.0.0-SNAPSHOT` resolves cleanly with no transitive surprises (no XP libs pulled transitively, no version conflicts).
- Runtime verification on a live XP 8 server was **not** performed.

## Test plan

- [ ] CI `./gradlew clean build` passes.
- [ ] Resolved `lib-util` version is `4.0.0-SNAPSHOT` (visible in dependency report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)