### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group = com.enonic.app
 projectName = rss
 appName = com.enonic.app.rss
 xpVersion=8.0.0-B4
-version=1.3.1-SNAPSHOT
+version=2.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary
- Bump master `version` from `1.3.1-SNAPSHOT` to `2.0.0-SNAPSHOT` to track XP 8 development.
- Add `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `1.x` so pushes to either branch are recognized as release builds.
- Companion PR on `1.x` adds the same workflow change so the maintenance branch's own workflow file lists itself.

## Test plan
- [ ] CI green on `chore/bump-to-next-major`
- [ ] After merge: `./gradlew clean build` from master is green