### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `releaseBranch:` block listing `master` and `1.x` to `.github/workflows/enonic-gradle.yml` on the `1.x` maintenance branch.
- This is required so pushes to `1.x` are recognized as release-branch builds — the `enonic/release-tools/build-and-publish` action reads `releaseBranch:` from the branch's own workflow file.
- Companion to the master PR (#76), which makes the same workflow change plus the version bump to `2.0.0-SNAPSHOT`.

## Test plan
- [ ] CI green on `chore/1.x-add-release-branch`
- [ ] After merge: a CI run on `1.x` classifies it as a release branch