### PR TITLE
Bump lib-thymeleaf, lib-xslt to 3.0.0-SNAPSHOT #78

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-thymeleaf = "2.1.1"
+thymeleaf = "3.0.0-SNAPSHOT"
 util = "4.0.0-SNAPSHOT"
-xslt = "2.1.1"
+xslt = "3.0.0-SNAPSHOT"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }

--- a/src/main/resources/lib/rss-xml/index.js
+++ b/src/main/resources/lib/rss-xml/index.js
@@ -237,11 +237,9 @@ function renderXml(params) {
 
 function commaStringToArray(str) {
 	if ( !str || str == '' || str == null) return null;
-	var commas = str || '';
-	var arr = commas.split(',');
-	arr = (Array.isArray(str) ? str : [str]); // Make sure we always work with an array
+	var arr = Array.isArray(str) ? str : str.split(','); // Make sure we always work with an array
 	if (arr) {
-		arr.map(function(s) { return s.trim() });
+		arr = arr.map(function(s) { return s.trim() });
 	}
 	//log.info('%s', JSON.stringify(arr, null, 4));
 	return arr;


### PR DESCRIPTION
Closes #78.

`lib-thymeleaf` and `lib-xslt` at `2.1.1` are XP-7 builds. Switch to the XP-8 SNAPSHOTs on `repo.enonic.com/dev` (already on the `xp.enonicRepo('dev')` repo list in `build.gradle`).

Verified locally against the runtime built from `xp-distro` at `xpVersion=8.0.0-B4`:

- Gradle build green with `--refresh-dependencies`; both SNAPSHOTs resolve from `dev`.
- Bundle reaches ACTIVE:

  ```
  INFO  ApplicationRegistryImpl - Started application com.enonic.app.rss bundle 117
  ```

- No `ERROR / Exception / NoSuchMethod / NoClassDefFound` attributable to the app during startup.

Note: a service-URL smoke (`/_/service/com.enonic.app.rss/rss?method=list` outside a site context) currently returns HTTP 500 due to a known XP-8 ServiceHandler NPE on `PortalRequest.getBaseUri()` — a platform issue, not an `app-rss` bug.