### PR TITLE
Drop lib-util

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ dependencies {
 	include xplibs.content
 	include xplibs.admin
 	include libs.lib.thymeleaf
-	include libs.lib.util
 	include libs.lib.xslt
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,7 @@
 [versions]
 thymeleaf = "2.1.1"
-util = "4.0.0-SNAPSHOT"
 xslt = "2.1.1"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
-lib-util = { module = "com.enonic.lib:lib-util", version.ref = "util" }
 lib-xslt = { module = "com.enonic.lib:lib-xslt", version.ref = "xslt" }

--- a/src/main/resources/cms/processors/add-meta.js
+++ b/src/main/resources/cms/processors/add-meta.js
@@ -1,8 +1,7 @@
 var libs = {
 	portal: require('/lib/xp/portal'),
 	content: require('/lib/xp/content'),
-    thymeleaf: require('/lib/thymeleaf'),
-    util: require('/lib/util')
+    thymeleaf: require('/lib/thymeleaf')
 };
 
 var conf = {
@@ -29,7 +28,7 @@ exports.responseProcessor = function (req, res) {
 	var metadata = libs.thymeleaf.render(conf.view, params);
 
 	// Add these to the site html head (can be picked up by browsers and other readers)
-	res.pageContributions.headEnd = libs.util.data.forceArray(res.pageContributions.headEnd);
+	res.pageContributions.headEnd = (Array.isArray(res.pageContributions.headEnd) ? res.pageContributions.headEnd : [res.pageContributions.headEnd]);
 	res.pageContributions.headEnd.push(metadata);
 
 	if (req.params.debug === 'true') {

--- a/src/main/resources/lib/rss-xml/index.js
+++ b/src/main/resources/lib/rss-xml/index.js
@@ -3,7 +3,6 @@ var libs = {
 	portal: require('/lib/xp/portal'),
 	auth: require('/lib/xp/auth'),
     xslt: require('/lib/xslt'),
-    util: require('/lib/util'),
     thymeleaf: require('/lib/thymeleaf'),
 	moment: require("/lib/moment-timezone")
 };
@@ -56,7 +55,7 @@ function getParams(site, content) {
 
 	// Content paths to include
 	if (content.data.include) {
-		content.data.include = libs.util.data.forceArray(content.data.include);
+		content.data.include = (Array.isArray(content.data.include) ? content.data.include : [content.data.include]);
 		var includeLength = content.data.include.length;
 		for (var i = 0; i < includeLength; i++) {
 			query += (i == 0) ? ' AND' : ' OR';
@@ -65,7 +64,7 @@ function getParams(site, content) {
 	}
 	// Content paths to exclude
 	if (content.data.exclude) {
-		content.data.exclude = libs.util.data.forceArray(content.data.exclude);
+		content.data.exclude = (Array.isArray(content.data.exclude) ? content.data.exclude : [content.data.exclude]);
 		var excludeLength = content.data.exclude.length;
 		for (var i = 0; i < excludeLength; i++) {
 			query += ' AND _path NOT LIKE "' + contentRoot + content.data.exclude[i] + '/*"';
@@ -130,7 +129,7 @@ function getParams(site, content) {
 
 		// Category handling
 		feedItem.categories = [];
-		var tmpCategories = libs.util.data.forceArray(itemData.categories);
+		var tmpCategories = (Array.isArray(itemData.categories) ? itemData.categories : [itemData.categories]);
 
 		if (JSON.stringify(tmpCategories) != "[null]") {
 			tmpCategories.forEach( function(category) {
@@ -240,11 +239,11 @@ function commaStringToArray(str) {
 	if ( !str || str == '' || str == null) return null;
 	var commas = str || '';
 	var arr = commas.split(',');
-	arr = libs.util.data.forceArray(str); // Make sure we always work with an array
+	arr = (Array.isArray(str) ? str : [str]); // Make sure we always work with an array
 	if (arr) {
 		arr.map(function(s) { return s.trim() });
 	}
-	//libs.util.log(arr);
+	//log.info('%s', JSON.stringify(arr, null, 4));
 	return arr;
 }
 


### PR DESCRIPTION
## Summary

Inline the two lib-util call sites and drop the dependency.

| call | replacement |
|---|---|
| `util.data.forceArray(x)` (4 sites in `lib/rss-xml/index.js`, 1 in `cms/processors/add-meta.js`) | `(Array.isArray(x) ? x : [x])` |

The replacements preserve lib-util's `forceArray(null) === [null]` semantics.

Also removes:
- `include libs.lib.util` from `build.gradle`
- The `util` version and the `lib-util` library entry from `gradle/libs.versions.toml`

A single commented-out `libs.util.log(arr)` line in `commaStringToArray` was rewritten to its plain-`log` equivalent, still commented.

## Test plan

- [x] `./gradlew build` is green
- [ ] Sanity check: an RSS page renders with `include`/`exclude` configured as a single string AND as a list (both paths through `forceArray`)
- [ ] `add-meta.js` site response processor still pushes `<link>` tags into `headEnd` when other contributions are present